### PR TITLE
FIX: HSCAN and snappy

### DIFF
--- a/redis/resp.go
+++ b/redis/resp.go
@@ -1081,13 +1081,33 @@ func (r *Resp) Uncompress(marker []byte) *Resp {
 		return nil
 	}
 	for i, arg := range vals {
-		if !arg.IsType(Str) {
+		if arg.IsType(Str) {
+			r2 := arg.Uncompress(marker)
+			if r2 != nil {
+				vals[i] = *r2
+			}
 			continue
 		}
-		r2 := arg.Uncompress(marker)
-		if r2 != nil {
-			vals[i] = *r2
+
+		if arg.IsType(Array) {
+			array, err := arg.Array()
+			if err != nil {
+				continue
+			}
+
+			for k, e := range array {
+				if !e.IsType(Str) {
+					continue
+				}
+				r2 := e.Uncompress(marker)
+				if r2 != nil {
+					// Should copy the pointer?
+					*array[k] = *r2
+				}
+			}
+			continue
 		}
+
 	}
 	return r
 


### PR DESCRIPTION
The responses that are coming from HSCAN command was able to use the
uncompress function. This patch will range over the results to
uncompress each of them if it's necessary.